### PR TITLE
Updated Docker File Kibana URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN rpm --rebuilddb && yum install -y tar && yum clean all
 
 # Install Kibana
 RUN cd /tmp \
-    && curl -O https://download.elasticsearch.org/kibana/kibana/kibana-4.0.2-linux-x64.tar.gz \
+    && curl -O https://download.elastic.co/kibana/kibana/kibana-4.0.2-linux-x64.tar.gz \
     && tar xzf kibana-*.tar.gz \
     && rm kibana-*.tar.gz \
     && mv kibana-* /opt/kibana


### PR DESCRIPTION
Kibana download URL was broken for Dockerfile build, noticed that there is a new primary URL. The old URL now works, but thought it might be worth using the primary URL for the future to avoid build failures.
